### PR TITLE
Fix caching of parking layer

### DIFF
--- a/config.js
+++ b/config.js
@@ -11,7 +11,7 @@ module.exports = {
   "/map/v1/hb-parking-map": {
     "source": `hbparking://`,
     "headers": {
-      "Cache-Control": "public,max-age=180"
+      "Cache-Control": "public,max-age=120"
     }
   },
   "/map/v1/roadworks-bw-map": {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,12 @@
     "tilelive-otp-citybikes": "HSLdevcom/tilelive-otp-citybikes#3f403de9859415146142f4f0b371ee258332c864",
     "tilelive-otp-routes": "HSLdevcom/tilelive-otp-routes",
     "tilelive-otp-stops": "HSLdevcom/tilelive-otp-stops",
-    "tilelive-hb-parking": "mfdz/tilelive-park-api",
+    "tilelive-hb-parking": "mfdz/tilelive-park-api#946700ddd36abbfa54956190d0902dec9bf2f876",
     "tilelive-roadworks-bw": "mfdz/tilelive-roadworks-bw#ca985f0c76d74ce2658f307cbeb81376185de4f0",
     "tilelive-vector": "^3.9.3",
     "tilelive-xray": "^0.4.0"
+  },
+  "resolutions": {
+    "**/tilelive-cache": "leonardehrenfried/tilelive-cache#21e07296fb5382bd44c31d6dae8498dda6bc0f8c"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3176,7 +3176,7 @@ tilelive-gl@hsldevcom/tilelive-gl#2f61ec0da7e5b13ca547fa5350905f3c2a688813:
 
 tilelive-hb-parking@mfdz/tilelive-park-api:
   version "0.0.1"
-  resolved "https://codeload.github.com/mfdz/tilelive-park-api/tar.gz/80697a7016e84715ce59ace4ddd213ffead4cac0"
+  resolved "https://codeload.github.com/mfdz/tilelive-park-api/tar.gz/eee5cf5c22dceafebc4d6433f2e4282a42fbd997"
   dependencies:
     geojson-vt "^2.1.8"
     requestretry "^1.6.0"


### PR DESCRIPTION
This is a bit of a complicated one as there were 3 interlocking bugs.

1. The cache duration is _not_ set in `config.js` but in the callback of the individual layer, i.e. here: https://github.com/mfdz/tilelive-park-api/blob/master/index.js#L78 or https://github.com/HSLdevcom/tilelive-otp-stops/blob/master/index.js#L165
2. `tilelive-cache` had a bug where the maxAge was a string, confusing the underlying caching lib: https://github.com/mojodna/tilelive-cache/pull/13
3. Lastly, the parkapi layer code _itself_ was also caching everything forever by reading the JSON file upon instantiation and then keeping it in memory: https://github.com/mfdz/tilelive-park-api/commit/0aa17301867a4ee06ab399790b596606addb1c7a

All of the above problems have been fixed in this PR.

I've already worked towards upstreaming this and once the PR is accepted I can see if it still works without those overrides.