### PR TITLE
Use released version of tilelive-cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "tilelive-xray": "^0.4.0"
   },
   "resolutions": {
-    "**/tilelive-cache": "leonardehrenfried/tilelive-cache#21e07296fb5382bd44c31d6dae8498dda6bc0f8c"
+    "tilelive-cache": "^0.7.2"
   }
 }


### PR DESCRIPTION
I've upstreamed my changes here https://github.com/mojodna/tilelive-cache/pull/13 and this uses the released npm module rather than my fork.

Once this works on our cluster, I will send a PR to HSL.